### PR TITLE
SignUpPage Auth with some Refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "wave",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/auth-ui-react": "^0.4.7",
+        "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/supabase-js": "^2.48.1",
         "@tailwindcss/vite": "^4.0.3",
         "clsx": "^2.1.1",
@@ -1230,6 +1232,12 @@
         "win32"
       ]
     },
+    "node_modules/@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.67.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
@@ -1237,6 +1245,30 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/auth-ui-react": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-react/-/auth-ui-react-0.4.7.tgz",
+      "integrity": "sha512-Lp4FQGFh7BMX1Y/BFaUKidbryL7eskj1fl6Lby7BeHrTctbdvDbCMjVKS8wZ2rxuI8FtPS2iU900fSb70FHknQ==",
+      "dependencies": {
+        "@stitches/core": "^1.2.8",
+        "@supabase/auth-ui-shared": "0.1.8",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.21.0"
+      }
+    },
+    "node_modules/@supabase/auth-ui-shared": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-shared/-/auth-ui-shared-0.1.8.tgz",
+      "integrity": "sha512-ouQ0DjKcEFg+0gZigFIEgu01V3e6riGZPzgVD0MJsCBNsMsiDT74+GgCEIElMUpTGkwSja3xLwdFRFgMNFKcjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.21.0"
       }
     },
     "node_modules/@supabase/functions-js": {
@@ -4337,7 +4369,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4804,7 +4835,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4867,8 +4897,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -6889,6 +6918,11 @@
       "integrity": "sha512-ar80GhdZb4DgmW3myIS9nRFYcpJRSME8iqWgzH2i44u+IdrzmiXVxeFnExQ5v4JYUSpg94bWjevMG8JHf1Da5Q==",
       "optional": true
     },
+    "@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
+    },
     "@supabase/auth-js": {
       "version": "2.67.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
@@ -6896,6 +6930,24 @@
       "requires": {
         "@supabase/node-fetch": "^2.6.14"
       }
+    },
+    "@supabase/auth-ui-react": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-react/-/auth-ui-react-0.4.7.tgz",
+      "integrity": "sha512-Lp4FQGFh7BMX1Y/BFaUKidbryL7eskj1fl6Lby7BeHrTctbdvDbCMjVKS8wZ2rxuI8FtPS2iU900fSb70FHknQ==",
+      "requires": {
+        "@stitches/core": "^1.2.8",
+        "@supabase/auth-ui-shared": "0.1.8",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "@supabase/auth-ui-shared": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-shared/-/auth-ui-shared-0.1.8.tgz",
+      "integrity": "sha512-ouQ0DjKcEFg+0gZigFIEgu01V3e6riGZPzgVD0MJsCBNsMsiDT74+GgCEIElMUpTGkwSja3xLwdFRFgMNFKcjg==",
+      "requires": {}
     },
     "@supabase/functions-js": {
       "version": "2.4.4",
@@ -8934,8 +8986,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
@@ -9215,7 +9266,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9254,8 +9304,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/auth-ui-react": "^0.4.7",
+    "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/supabase-js": "^2.48.1",
     "@tailwindcss/vite": "^4.0.3",
     "clsx": "^2.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SignInPage from "./pages/auth/SigninPage";
-import SignOutPage from "./pages/auth/SignUpPage";
+import SignUpPage from "./pages/auth/SignUpPage";
+import Dashboard from "./pages/Dashboard";
 
 function App() {
   return (
@@ -8,7 +9,8 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<SignInPage />} />
-          <Route path="/sign-up" element={<SignOutPage />} />
+          <Route path="/sign-up" element={<SignUpPage />} />
+          <Route path="/dashboard" element={<Dashboard />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/src/pages/Dashboard/index.jsx
+++ b/src/pages/Dashboard/index.jsx
@@ -1,0 +1,11 @@
+const Dashboard = () => {
+return (
+  <>
+    <div className="flex w-full bg-blue-700 font-lato text-4xl"
+    >Welcome to the dashboard page
+    </div>
+  </>
+)
+};
+
+export default Dashboard

--- a/src/pages/auth/AuthForm/index.jsx
+++ b/src/pages/auth/AuthForm/index.jsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
 import Field from "./Field";
-import * as userService from "../../../services/users";
+
+// import * as userService from "../../../services/users";
 
 const AuthForm = (props) => {
-  const { fields, submitButtonLabel } = props;
+
+  const { fields, submitButtonLabel, onSubmit } = props;
+
+
   //keep track of the input the user is doing each time
   const [fieldValues, setFieldValues] = useState(() => {
     //default value needs to be an object
@@ -16,10 +20,21 @@ const AuthForm = (props) => {
     return initialState;
   });
 
+
+
   return (
     <>
     <form className="font-lato m-4 p-4 bg-white border border-slate-300 rounded-lg"
-    onSubmit={(e) => userService.createUser(e, fieldValues)}
+    onSubmit={async (e) => {
+      e.preventDefault(); 
+      if (onSubmit) {
+        await onSubmit(fieldValues);
+        console.log("Form submitted");
+      } else {
+        console.error("onSubmit function is undefined!");
+      }
+    }}
+
     >
       {fields.map((field) => (
         <Field
@@ -35,14 +50,17 @@ const AuthForm = (props) => {
               ...fieldValues,
               [field.label]: e.target.value,
             });
+            // console.log(`updating field ${field.label}:`, e.target.value)
           }}
         />
       ))}
       <button
+      type="submit"
         className="bg-blue-700 text-white p-4 w-full rounded-lg 
 py-3 shadow-md mt-4"
       >
         {submitButtonLabel}
+        
       </button>
     </form>
     

--- a/src/pages/auth/SignInPage.jsx
+++ b/src/pages/auth/SignInPage.jsx
@@ -3,7 +3,10 @@ import FormContainer from "./FormContainer";
 import { Link } from "react-router-dom";
 
 
+
+
 const SignInPage = () => {
+
 
   return (
     <>
@@ -32,4 +35,4 @@ const SignInPage = () => {
   );
 };
 
-export default SignInPage;
+export default SignInPage

--- a/src/pages/auth/SignUpPage.jsx
+++ b/src/pages/auth/SignUpPage.jsx
@@ -1,11 +1,83 @@
-import { Link } from "react-router-dom";
 import AuthForm from "./AuthForm";
 import FormContainer from "./FormContainer";
+import { Link } from "react-router-dom";
+import * as userService from "../../services/users";
+import supabase from "../../services/supabase-client";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+
+
 
 
 
 const SignUpPage = () => {
 
+  const navigate = useNavigate();
+
+
+  const [session, setSession ] = useState(null);
+
+  useEffect(() => {
+    const getInitialSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      setSession(session)
+
+      if(!session) {
+        console.log('no active session...redirecting.')
+        navigate('/sign-up')
+      }
+    };
+
+
+    getInitialSession();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        setSession(session);
+        if(session) {
+          console.log('user session data', session);
+          navigate('/dashboard')
+        } else {
+          navigate("/sign-up")
+        }
+      }
+    );
+
+    return () => {
+      authListener.subscription.unsubscribe();
+    };
+
+  }, [navigate])
+
+  // useEffect(() => {
+  //   (async () => {
+  //     supabase.auth.getSession().then(( { data: { session } }) => {
+  //       setSession(session);
+  //     })
+  //     if(session) {
+  //       console.log('session data -->', session)
+  //       navigate('/dashboard')
+  //     }
+  //   })();
+
+  // });
+
+
+
+  const handleSubmit = async (fieldValues) => {
+    try {
+      await userService.creatingAccount(fieldValues);
+      console.log("Account created successfully!");
+    } catch (error) {
+      console.error("Error creating user:", error);
+    }
+    //TODO - LOOK INTO THE NAVIGATION OF WHEN THE USER CREATES AN ACCOUNT. 
+    // if(session.access_token) {
+    //   console.log('our session', session)
+    //   navigate("/dashboard")
+    // }
+  };
 
 
 
@@ -28,10 +100,12 @@ const SignUpPage = () => {
                 type: "password",
               },
             ]}
-            submitButtonLabel="create account"
+            submitButtonLabel="Create an account"
+            onSubmit={handleSubmit}
             
-          />
-          <Link to="/" className="text-blue-600 underline">
+            />
+          <Link to="/" 
+          className="text-blue-600 underline">
             Sign in
           </Link>
         </div>
@@ -40,4 +114,52 @@ const SignUpPage = () => {
   );
 };
 
-export default SignUpPage;
+export default SignUpPage
+
+
+
+
+
+// import { Link } from "react-router-dom";
+// import AuthForm from "./AuthForm";
+// import FormContainer from "./FormContainer";
+
+
+
+// const SignUpPage = () => {
+
+
+
+
+//   return (
+//     <>
+//       <FormContainer>
+//         <div className="flex flex-col justify-center items-center">
+//           <AuthForm
+//             fields={[
+//               {
+//                 label: "username",
+//                 type: "text",
+//               },
+//               {
+//                 label: "password",
+//                 type: "password",
+//               },
+//               {
+//                 label: "confirm password",
+//                 type: "password",
+//               },
+//             ]}
+//             submitButtonLabel="create account"
+            
+//           />
+//           <Link to="/" className="text-blue-600 underline">
+//             Sign in
+//           </Link>
+//         </div>
+//       </FormContainer>
+//     </>
+//   );
+// };
+
+// export default SignUpPage;

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -1,18 +1,19 @@
 import supabase from "./supabase-client";
 
-export const createUser = async (e, fieldValues) => {
-  e.preventDefault();
+
+export const creatingAccount = async (fieldValues) => {
+
 
   console.log("Submitting with the Field values:", fieldValues);
   
   const { data, error } = await supabase.auth.signUp({
     email: fieldValues.username,
     password: fieldValues.password
-  })
-  console.log("supabase response", { data, error})
+  });  
   if (error) {
     console.error("Error signing up:", error.message);
   } else {
     console.log("User created successfully:", data);
+
   }
 }


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
Cleaned up the `SignUpPage` to allow users to create an account which authenticates the account and provides session data, auth key to allow them to be redirected to our `/dashboard` page. 


**Previous behavior**
Once the user created an account we were only monitoring that the account was authenticated in the supabase dashboard.

**Expected behavior**
Creating a new account will show the authenticated account in Supabase as well as redirecting the user to our dashboard page.

