### PR TITLE
Updated the state for Quantity and Few UI Changes

### DIFF
--- a/src/contexts/PortfolioContext.jsx
+++ b/src/contexts/PortfolioContext.jsx
@@ -4,9 +4,10 @@ const PortfolioContext = createContext();
 
 export const PortfolioProvider = ({ children }) => {
   const [portfolioValue, setPortfolioValue] = useState(0);
+  const [qty, setQty] = useState(0);
 
   return (
-    <PortfolioContext.Provider value={{ portfolioValue, setPortfolioValue }}>
+    <PortfolioContext.Provider value={{ portfolioValue, setPortfolioValue, qty, setQty }}>
       {children}
     </PortfolioContext.Provider>
   );

--- a/src/pages/auth/AuthForm/index.jsx
+++ b/src/pages/auth/AuthForm/index.jsx
@@ -55,7 +55,7 @@ const AuthForm = (props) => {
           type="submit"
           className="relative flex justify-center items-center bg-blue-700 text-white p-5 w-full rounded-lg 
 py-3 shadow-md mt-4"
-          onSubmit={fieldValues}
+          onSubmit={() =>fieldValues}
         >
           {submitButtonLabel}
           <span className="w-5 h-5 inline-flex items-center justify-center">

--- a/src/shared-components/AddToValueBtn.jsx
+++ b/src/shared-components/AddToValueBtn.jsx
@@ -5,16 +5,10 @@ const AddToValueBtn = ({ isAdded, handleClick }) => {
     <button 
       onClick={handleClick}
       disabled={isAdded}
-      className={clsx(
-        " relativepx-4 py-2 rounded-md",
-        !isAdded && "bg-blue-500 text-white p-2 mt-2"
-      )}
+      className="p-3"
       >
-        {isAdded ? (
-          <i className="absolute left-0bg-none text-xl text-green-500 fa-solid fa-check-to-slot"></i>
-        ) : (
-          'Add to Portfolio'
-        )}
+     <i className="flex w-6 h-6 items-center justify-center rounded-full text-lg border border-emerald-500 text-emerald-500 fa-solid fa-plus"></i>
+  
       </button>
   );
 }

--- a/src/shared-components/Card.jsx
+++ b/src/shared-components/Card.jsx
@@ -1,45 +1,52 @@
-import { useState } from 'react';
-import AddToValueBtn from './AddToValueBtn';
-import { usePortfolio } from '../contexts/PortfolioContext';
+import { useEffect } from "react";
+import AddToValueBtn from "./AddToValueBtn";
+import { usePortfolio } from "../contexts/PortfolioContext";
 
 const Card = (props) => {
-  const [isAdded, setIsAdded] = useState(false);
-  const { product } = props;
-const { setPortfolioValue } = usePortfolio(); 
+  const { product, quantity, onQuantityChange } = props;
+  const { setPortfolioValue } = usePortfolio();
 
-  console.log("details of our individual product", product)
+  console.log("details of our individual product", product);
 
-  const price = product['loose-price'] / 100;
-  const consoleName = product['console-name'];
-  const consoleNameParts = consoleName.split(' ');
-  const setName = consoleNameParts.slice(1, 3).join(' ');
+  const price = product["loose-price"] / 100;
+  const consoleName = product["console-name"];
+  const consoleNameParts = consoleName.split(" ");
+  const setName = consoleNameParts.slice(1, 3).join(" ");
 
-  const handleAddToPortfolio = () => {
-    setIsAdded(true);
-    setPortfolioValue(prevValue => prevValue + price);
-    console.log("value", value);
-    console.log("button handleAddToPortfolio was clicked");
-  }
+  const handleQtyAndValueInPortfolio = () => {
+    setPortfolioValue((prevValue) => prevValue + price);
+    onQuantityChange(quantity + 1);
+    console.log("button handleQtyAndValueInPortfolio was clicked");
+  };
 
+  useEffect(() => {
+    console.log("qty", quantity);
+  }, [quantity]);
 
-    return (
-      <>
-        <div className=" bg-white font-lato border border-slate-400 rounded-lg h-96 w-72 p-8 shadow-xl">
-          <img src="images/skyridgeBoosterbox.png" className="w-full h-36 object-contain" />
-            <div className="mt-4 text-slate-700 text-xl">{setName + " " + product['product-name']}</div>
-              <div className="text-slate-400 font-playfair text-sm">{setName}</div>
-            <div className="text-slate-400 mt-4 font-playfair">
-              <div className="text-slate-800">${price}</div>
-              {/* <div>{product['product-name']}</div> */}
-              <div>Qty: 1</div>
-              <div>
-                <AddToValueBtn isAdded={isAdded} handleClick={handleAddToPortfolio} />
-                </div>
-            </div>
+  return (
+    <>
+      <div className=" bg-white font-lato border border-slate-400 rounded-lg h-96 w-72 p-8 shadow-xl">
+        <img
+          src="images/skyridgeBoosterbox.png"
+          className="w-full h-36 object-contain"
+        />
+        <div className="mt-4 text-slate-700 text-xl">
+          {setName + " " + product["product-name"]}
         </div>
-      </>
-    )
+        <div className="text-slate-400 font-playfair text-sm">{setName}</div>
+        <div className="mt-2 w-full border-b border-slate-300 w=[1px]"></div>
+        <div className=" flex flex-col justify-end text-slate-400 mt-10 font-playfair">
+          <div className="flex justify-between items-end">
+            <div className="mb-1">
+              <div className="text-slate-800">${price}</div>
+              <div>Qty: {quantity}</div>
+            </div>
+            <AddToValueBtn handleClick={handleQtyAndValueInPortfolio} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default Card;
-

--- a/src/shared-components/PortfolioValue.jsx
+++ b/src/shared-components/PortfolioValue.jsx
@@ -14,7 +14,7 @@ const PortfolioValue = () => {
           <span className="text-emerald-500 font-lato">
             +$500.75 in the last 30 days
           </span>
-          <AddToValueBtn/>
+          {/* <AddToValueBtn/> */}
         </div>
       </div>
     </>

--- a/src/shared-components/ProductSearchPage.jsx
+++ b/src/shared-components/ProductSearchPage.jsx
@@ -4,14 +4,16 @@ import SearchBar from "./SearchBar";
 import Card from "./Card";
 
 const ProductSearchPage = (props) => {
+
   const [products, setProducts] = useState([]);
   const { value, setValue } = props;
   useEffect(() => {
-    console.log("product objectt with new products being added", products);
+    console.log("product object with new products being added", products);
   }, [products]);
 
   const handleSearch = async (query) => {
     console.log("search button was clicked with query", query);
+  
     if (!query) {
       setProducts([]);
       return;
@@ -21,10 +23,25 @@ const ProductSearchPage = (props) => {
     console.log("API response inside ProductSearchPage component", data);
 
     if (data) {
-      setProducts([...products, data]); // Store the single product in an array
+      const productWithQuantity = {
+        ...data, 
+        quantity: 0,
+        searchId: Date.now(),
+      }
+      setProducts(prevProducts => [...prevProducts, productWithQuantity]);
     } else {
       console.error("Invalid data received", data);
     }
+  };
+
+  const updateQuantity = (searchId, newQuantity) => {
+    setProducts(prevProducts =>
+      prevProducts.map(product =>
+        product.searchId === searchId 
+          ? { ...product, quantity: newQuantity } 
+          : product
+      )
+    );
   };
 
   return (
@@ -40,13 +57,17 @@ const ProductSearchPage = (props) => {
             {products.length > 0 ? (
               <ul className="flex justify-center flex-wrap">
                 {products.map((product) => (
-                  <li key={product.id}>
-                    {
-                      <div className="m-8">
-                        <Card product={product} value={value} setValue={setValue}  />
-                      </div>
-                    }
-                  </li>
+                 <li key={product.searchId}>
+                 <div className="m-8" key={product.searchId}>
+                   <Card 
+                     product={product} 
+                     value={value} 
+                     setValue={setValue} 
+                     quantity={product.quantity}
+                     onQuantityChange={(newQty) => updateQuantity(product.searchId, newQty)}
+                   />
+                 </div>
+               </li>
                 ))}
               </ul>
             ) : (

--- a/src/shared-components/SearchBar.jsx
+++ b/src/shared-components/SearchBar.jsx
@@ -34,7 +34,7 @@ const SearchBar = ({ onSearch }) => {
         </button>
         {/* Search button */}
         <button
-          className="ml-4 flex items-center rounded-lg bg-blue-700 py-1 px-2.5 border border-transparent text-center text-sm text-white transition-all shadow-sm hover:shadow focus:bg-blue-800 focus:shadow-none active:bg-blue-800 hover:bg-blue-800 active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
+          className="ml-4 flex items-center rounded-lg bg-blue-500 py-1 px-2.5 border border-transparent text-center text-sm text-white transition-all shadow-sm hover:shadow focus:bg-blue-800 focus:shadow-none active:bg-blue-800 hover:bg-blue-800 active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"
           type="button"
           onClick={handleSearch}
         >


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Clicking on the `+`button on the card will now increase the quantity for the individual card. If you run another search, you'll notice the quantity is at 0 because nothing was added for that card.



**Previous behavior**
The UI previously had an `add to Portfolio` button which did increase the value and changed the button to an icon indicating that the item was added. However, it only allowed the user to add a single quantity of that item which is going to be rare. We wanted to allow users to search an item > increase the quantity to whatever denomination they choose.

**Expected behavior**
You'll be able to continue to search for an item which will populate a card. You can now continue to add that item to the value but now the quantity will increase dynamically for each individual card.

**Screenshots & Videos**
<img width="773" alt="Screenshot 2025-03-02 at 12 11 11 PM" src="https://github.com/user-attachments/assets/f39a421c-25cd-4214-b5bf-383ca4e6c66e" />



