### PR TITLE
Updated the UI on the Card component and added the qty state.

### DIFF
--- a/src/shared-components/Card.jsx
+++ b/src/shared-components/Card.jsx
@@ -1,6 +1,8 @@
-import {useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 const Card = (props) => {
+  const { product } = props;
+  const [qty, setQty] = useState(0);
 
   const images = [
     "public/images/brilliantStars.png",
@@ -11,33 +13,52 @@ const Card = (props) => {
     "public/images/prismatic.png",
     "public/images/skyridgeBoosterbox.png",
   ];
-  const { product } = props;
-  
+
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  });
+
+  const dollarFormatter = formatter.format(product["loose-price"] / 100);
   const combinedName = product["console-name"] + " " + product["product-name"];
   const productName = combinedName.split(" ").slice(1).join(" ");
-  
+
   const editedSetName = product["console-name"].split(" ");
   const setName = editedSetName.slice(1).join(" ");
-  
+
   const randomIdx = Math.floor(Math.random() * 6);
   const [randomImg, setRandomImg] = useState("");
+
   useEffect(() => {
     setRandomImg(images[randomIdx]);
   }, []);
 
+  const increaseQty = () => {
+    setQty((prev) => prev + 1);
+  };
+
   return (
     <>
       <div className="p-4">
-        <div className="flex flex-col border border-slate-500 w-72 h-96 rounded-lg shadow-lg">
+        <div className="flex flex-col border border-slate-200 w-72 h-96 rounded-lg shadow-lg">
           <div>
             <img
               src={randomImg}
               className="w-72 h-56 rounded-t-md object-cover"
             />
           </div>
-          <div className="pl-4 mt-8">
-            <div className="font-lato text-2xl">{setName}</div>
-            <div>{productName}</div>
+          <div className="pl-4 mt-2">
+            <div className="font-lato text-xl">{productName}</div>
+            <div>{setName}</div>
+          </div>
+          <div className="mt-auto pl-4 flex flex-col  font-playfair ">
+            <div>{dollarFormatter}</div>
+            <div className="flex justify-between mb-1">
+              <div>Qty: {qty}</div>
+              <button 
+              onClick={increaseQty}
+              className="pr-4 text-2xl fa-solid fa-circle-plus text-emerald-500"></button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Updated the UI on the Card component to display the price of the product, the qty, and an add button to increment the state of the qty.


**Previous behavior**
Previously, there was no price, qty, or the ability to increment the state of the qty.

**Expected behavior**
Clicking on the `+`button on the card will increment the state of the `qty`and each card should have a dollar value associated with it. 

**Screenshots & Video**
<img width="1032" alt="Screenshot 2025-04-02 at 3 40 51 PM" src="https://github.com/user-attachments/assets/4c069ad9-48d2-4fda-8bd4-9b96decf513d" />

